### PR TITLE
Add option to enable\disable bounce

### DIFF
--- a/DKCarouselView/DKCarouselView.h
+++ b/DKCarouselView/DKCarouselView.h
@@ -57,6 +57,7 @@ typedef void(^DKCarouselViewDidScrollBlock)(DKCarouselView *view, NSInteger offs
 
 // set infinite slide or not, defaults to NO.
 @property (nonatomic, assign, getter = isFinite) BOOL finite;
+@property (nonatomic, assign) BOOL bounce;
 
 // set selected page index
 @property (nonatomic, assign) NSUInteger selectedPage;

--- a/DKCarouselView/DKCarouselView.m
+++ b/DKCarouselView/DKCarouselView.m
@@ -122,8 +122,8 @@ typedef void(^DKCarouselViewTapBlock)();
     UIScrollView *scrollView = [UIScrollView new];
     scrollView.showsHorizontalScrollIndicator = scrollView.showsVerticalScrollIndicator = NO;
     scrollView.pagingEnabled = YES;
-    scrollView.bounces = NO;
     scrollView.scrollsToTop = NO;
+    scrollView.bounces = _bounce;
     scrollView.delegate = self;
     
     self.indicatorTintColor = [UIColor whiteColor];
@@ -195,8 +195,11 @@ typedef void(^DKCarouselViewTapBlock)();
 
 - (void)setFinite:(BOOL)finite {
     _finite = finite;
-    
-    self.scrollView.bounces = finite;
+}
+
+- (void)setBounce:(BOOL)bounce {
+    _bounce = bounce;
+    self.scrollView.bounces = bounce;
 }
 
 - (void)setIndicatorTintColor:(UIColor *)indicatorTintColor {

--- a/DKCarouselViewDemo/DKCarouselViewDemo/ViewController.m
+++ b/DKCarouselViewDemo/DKCarouselViewDemo/ViewController.m
@@ -33,9 +33,10 @@
         [items addObject:urlAD];
     }
     self.carouselView.defaultImage = [UIImage imageNamed:@"DefaultImage"];
-//    [self.carouselView setFinite:YES];
+    [self.carouselView setFinite:YES];
+    [self.carouselView setBounce: NO];
     [self.carouselView setItems:items];
-    [self.carouselView setAutoPagingForInterval:2];
+    //[self.carouselView setAutoPagingForInterval:2];
     [self.carouselView setDidSelectBlock:^(DKCarouselItem *item, NSInteger index) {
         NSLog(@"%zd",index);
     }];


### PR DESCRIPTION
Previously the scroll was tied to the finite property, doesn't make sense.

This allows you to set finite to false, and bounce to false so the first and last slide wont scroll past their bounds.